### PR TITLE
Mesh/RenderComponent Overhaul

### DIFF
--- a/Headers/EntityComponentHeaders/RenderComponent.h
+++ b/Headers/EntityComponentHeaders/RenderComponent.h
@@ -27,16 +27,8 @@ public:
 	void update(double dTimeStep);
 	void updateCount(GLsizei iNewCount) { m_iCount = iNewCount; }
 
-	void generateDiffuseTexture(const vec4* vColor);
-
 	// Initializes the proper buffers on the GPU for rendering.
-	void initializeComponent( Mesh const  * pMesh, 
-							  const Material* pMaterial = nullptr);
-
-	void getDiffuseTextureDimensions(int* iHeight, int* iWidth);
-
-	// Function to load Material for Render Component
-	void loadMaterial(const Material* pMaterial);
+	void initializeComponent( Mesh const  * pMesh );
 
 private: 
 	// Private Copy Constructor and Assignment operator overload.
@@ -53,12 +45,4 @@ private:
 	bool m_bUsingIndices, m_bUsingInstanced;
 	ShaderManager* m_pShdrMngr;
 	ShaderManager::eShaderType m_eShaderType;
-
-	// Material Struct for setting uniform in Lighting Shaders
-	struct sRenderMaterial
-	{
-		Texture* m_pDiffuseMap;
-		Texture* m_pSpecularMap;
-		float fShininess;
-	} m_sRenderMaterial;
 };

--- a/Headers/EntityManager.h
+++ b/Headers/EntityManager.h
@@ -4,7 +4,6 @@
 #include "EntityHeaders/DirectionalLight.h"
 #include "EntityHeaders/SpotLight.h"
 #include "Scene_Loader.h"
-#include "BoidEngine.h"
 #include "EmitterEngine.h"
 #include "EntityHeaders/InteractableEntity.h"
 #include "EntityHeaders/Entity.h"
@@ -40,7 +39,7 @@ public:
 
 	// Entity Component functions
 	CameraComponent* generateCameraComponent(int iEntityID);
-	RenderComponent* generateRenderComponent(int iEntityID, bool bStaticDraw, ShaderManager::eShaderType eType, GLenum eMode);
+	RenderComponent* generateRenderComponent(int iEntityID, Mesh const* pMeshKey, bool bStaticDraw, ShaderManager::eShaderType eType, GLenum eMode);
 	LightingComponent* generateLightingComponent(int iEntityID);
 
 	// Camera Management
@@ -65,31 +64,25 @@ public:
 	void setMaxThreshold( float fMax ) { m_fMaxEdgeThreshold = fMax; }
 	float getMaxThreshold() { return m_fMaxEdgeThreshold; }
 
-	// Boid Methods
-	void initializeBoidEngine(vector< string >& sData);
-
 private:
 	EntityManager();
 	EntityManager(const EntityManager* pCopy);
 	static EntityManager* m_pInstance;
-
-	// Object Managing
-	BoidEngine* m_pBoidEngine;
 
 	// Entity Managing
 	int m_iEntityIDPool, m_iComponentIDPool;
 	int m_iHeight, m_iWidth;
 	inline int getNewEntityID() { return ++m_iEntityIDPool; }
 	inline int getNewComponentID() { return ++m_iComponentIDPool; }
-	vector<unique_ptr<EntityComponent>>	m_pMasterComponentList;
-	vector<unique_ptr<Entity>>			m_pMasterEntityList;
-	vector<RenderComponent*>			m_pRenderingComponents;
-	vector<CameraComponent*>			m_pCameraComponents;
-	vector<LightingComponent*>			m_pLights;
-	CameraComponent*					m_pActiveCamera;
-	DirectionalLight*					m_pDirectionalLight;
-	InteractableEntity*					m_pBillboardTesting;
-	PointLight*							m_pTestingLight; // Temporary, Needs to be removed.
+	vector<unique_ptr<EntityComponent>>				m_pMasterComponentList;
+	vector<unique_ptr<Entity>>						m_pMasterEntityList;
+	unordered_map<Mesh const*, RenderComponent*>	m_pRenderingComponents;
+	vector<CameraComponent*>						m_pCameraComponents;
+	vector<LightingComponent*>						m_pLights;
+	CameraComponent*								m_pActiveCamera;
+	DirectionalLight*								m_pDirectionalLight;
+	InteractableEntity*								m_pBillboardTesting;
+	PointLight*										m_pTestingLight; // Temporary, Needs to be removed.
 
 	// Manage Pointers for Deletion.
 	MeshManager*				m_pMshMngr;

--- a/Headers/Mesh.h
+++ b/Headers/Mesh.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "stdafx.h"
 #include "ShaderManager.h"
+#include "Texture.h"
 
 //////////////////////////////////////////////////////////////////
 // Name: Mesh.h
@@ -24,9 +25,21 @@ private:
 	void addCarteseanPoint(float fPhi, float fTheta, float fRadius);
 	void initalizeVBOs();
 	bool loadObj(const string& sFileName);
+	void loadMaterial(const Material* pMaterial);
+
+	// function to generate a quaternion to rotate from y-axis normal to specified normal
+	mat4 getRotationMat4ToNormal(const vec3* vNormal);
 
 	// VBO Initialization
 	void setupInstanceBuffer(GLuint iStartSpecifiedIndex);
+
+	// Material Struct for setting uniform in Lighting Shaders
+	struct sRenderMaterial
+	{
+		Texture* m_pDiffuseMap;
+		Texture* m_pSpecularMap;
+		float fShininess;
+	} m_sRenderMaterial;
 
 	// Indices for Faces of Mesh and Additional Buffer Addresses on the GPU for
 	//	Indices and Normals
@@ -55,7 +68,7 @@ private:
 	struct manager_cookie {};
 
 public:
-	explicit Mesh(const string &sFileName, bool bStaticMesh, manager_cookie);
+	explicit Mesh(const string &sFileName, bool bStaticMesh, const Material* pMaterial, manager_cookie);
 	virtual ~Mesh();
 	void loadInstanceData(const void* pData, unsigned int iSize);
 
@@ -75,8 +88,8 @@ public:
 	bool usingInstanced() const { return 0 != m_iInstancedBuffer; }
 
 	// Function to add a new Instance Matrix for the Mesh. If the Mesh is dynamic, it will replace the current instance, static will add a new instance.
-	void addInstance(const vec3* vPosition, quat qRotation, float fScale);	// Specify particular components and a transformation matrix will be generated
-	void addInstance(const mat4* m4Transform);								// Specify a previously generated transformation matrix
+	void addInstance(const vec3* vPosition, const vec3* vNormal, float fScale);	// Specify particular components and a transformation matrix will be generated
+	void addInstance(const mat4* m4Transform);									// Specify a previously generated transformation matrix
 
 	// Billboard Usage
 	unsigned int addBillboard(const vec3* vPosition, const vec3* vNormal, const vec2* vUVStart, const vec2* vUVEnd, int iHeight, int iWidth);
@@ -88,6 +101,10 @@ public:
 	const vector<vec3>& getNormals() const { return m_pNormals; }
 	const vector<vec2>& getUVs() const { return m_pUVs; }
 	GLuint getVertexArray() const { return m_iVertexArray; }
+
+	// Functionality for Binding and Unbinding Textures
+	void bindTextures(ShaderManager::eShaderType eShaderType) const ;
+	void unbindTextures() const;
 
 	// Gets the file name, only the MeshManager can set this variable.
 	const string& getManagerKey() { return m_sManagerKey; }

--- a/Headers/MeshManager.h
+++ b/Headers/MeshManager.h
@@ -11,11 +11,11 @@ public:
 	~MeshManager();
 
 	// Methods:
-	Mesh* loadMeshFromFile( const string &sFileName, float fScale = 1.0f, vec3 vPosition = vec3(0.f), bool bStaticMesh = false );
-	Mesh* generatePlaneMesh(bool bStaticMesh, int iHeight, int iWidth, vec3 vPosition = vec3(0.f), vec3 vNormal = vec3(0.f, 1.f, 0.f));
-	Mesh* generateSphereMesh(bool bStaticMesh, float fRadius, vec3 vPosition = vec3(0.f));
-	Mesh* generateCubeMesh(bool bStaticMesh, int iHeight, int iWidth, int iDepth, vec3 vPosition = vec3(0.f));
-	Mesh* generateBillboardMesh(vec3 vPosition, vec3 vNormal, vec2 vUVStart, vec2 vUVEnd, int iHeight, int iWidth);
+	Mesh* loadMeshFromFile( const string &sFileName, const Material* pMaterial, float fScale = 1.0f, vec3 vPosition = vec3(0.f), bool bStaticMesh = false);
+	Mesh* generatePlaneMesh(bool bStaticMesh, int iHeight, int iWidth, const Material* pMaterial, vec3 vPosition = vec3(0.f), vec3 vNormal = vec3(0.f, 1.f, 0.f));
+	Mesh* generateSphereMesh(bool bStaticMesh, float fRadius, const Material* pMaterial, vec3 vPosition = vec3(0.f));
+	Mesh* generateCubeMesh(bool bStaticMesh, int iHeight, int iWidth, int iDepth, const Material* pMaterial, vec3 vPosition = vec3(0.f));
+	Mesh* generateBillboardMesh(vec3 vPosition, vec3 vNormal, vec2 vUVStart, vec2 vUVEnd, int iHeight, int iWidth, const Material* pMaterial);
 	void unloadAllMeshes();
 
 private:
@@ -26,7 +26,7 @@ private:
 	MeshManager& operator=( const MeshManager& pRHS ) {}
 	
 	// Private Functions
-	bool initializeMesh( Mesh* pMesh, const string& sFileName, vec3 vPosition, float fScale );
+	string materialToString( const Material* sMaterial );
 
 	// Hash Map
 	unordered_map<string, unique_ptr<Mesh>> m_pMeshCache;

--- a/Headers/Scene_Loader.h
+++ b/Headers/Scene_Loader.h
@@ -1,6 +1,5 @@
 #pragma once
 #include "stdafx.h"
-#include "Anim_Track.h"
 
 // Solely Generates Objects and assigns IDs to them.
 class Scene_Loader
@@ -16,7 +15,7 @@ public:
 	void createDirectionalLight(vector< string > sData, int iLength);
 	void createSpotLight(vector< string > sData, int iLength);
 	void createPlayer(vector< string > sData, int iLength);
-	void createStaticMesh(vector< string > sData, int iLength);
+	void createStaticMesh(vector< string > sData, unsigned int iLength);
 
 	void loadFromFile( string sFileName );
 
@@ -27,7 +26,6 @@ private:
 	static Scene_Loader* m_pInstance;
 	string m_sMeshProperty, m_sShaderProperty;
 	float m_fMeshScaleProperty;
-	Anim_Track* m_pAnimProperty;
 	Material m_pMaterialProperty;
 
 	long m_lNextID;

--- a/Headers/stdafx.h
+++ b/Headers/stdafx.h
@@ -99,6 +99,7 @@ using namespace glm;
 struct Material
 {
 	string sDiffuseMap;
+	vec4 vOptionalDiffuseColor;
 	string sOptionalSpecMap;
 	vec4 vOptionalSpecShade;
 	float fShininess;

--- a/Renderer.sln
+++ b/Renderer.sln
@@ -9,26 +9,16 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "UnitTests", "UnitTests\Unit
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|x64 = Debug|x64
 		Debug|x86 = Debug|x86
-		Release|x64 = Release|x64
 		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{6C141890-2C00-4BA8-B8C9-1C8AC5A5FD3B}.Debug|x64.ActiveCfg = Debug|x64
-		{6C141890-2C00-4BA8-B8C9-1C8AC5A5FD3B}.Debug|x64.Build.0 = Debug|x64
 		{6C141890-2C00-4BA8-B8C9-1C8AC5A5FD3B}.Debug|x86.ActiveCfg = Debug|Win32
 		{6C141890-2C00-4BA8-B8C9-1C8AC5A5FD3B}.Debug|x86.Build.0 = Debug|Win32
-		{6C141890-2C00-4BA8-B8C9-1C8AC5A5FD3B}.Release|x64.ActiveCfg = Release|x64
-		{6C141890-2C00-4BA8-B8C9-1C8AC5A5FD3B}.Release|x64.Build.0 = Release|x64
 		{6C141890-2C00-4BA8-B8C9-1C8AC5A5FD3B}.Release|x86.ActiveCfg = Release|Win32
 		{6C141890-2C00-4BA8-B8C9-1C8AC5A5FD3B}.Release|x86.Build.0 = Release|Win32
-		{95109BEF-6226-49BA-B1F5-9060C5547620}.Debug|x64.ActiveCfg = Debug|x64
-		{95109BEF-6226-49BA-B1F5-9060C5547620}.Debug|x64.Build.0 = Debug|x64
 		{95109BEF-6226-49BA-B1F5-9060C5547620}.Debug|x86.ActiveCfg = Debug|Win32
 		{95109BEF-6226-49BA-B1F5-9060C5547620}.Debug|x86.Build.0 = Debug|Win32
-		{95109BEF-6226-49BA-B1F5-9060C5547620}.Release|x64.ActiveCfg = Release|x64
-		{95109BEF-6226-49BA-B1F5-9060C5547620}.Release|x64.Build.0 = Release|x64
 		{95109BEF-6226-49BA-B1F5-9060C5547620}.Release|x86.ActiveCfg = Release|Win32
 		{95109BEF-6226-49BA-B1F5-9060C5547620}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection

--- a/Renderer.vcxproj
+++ b/Renderer.vcxproj
@@ -19,8 +19,6 @@
     </ProjectConfiguration>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Headers\Anim_Track.h" />
-    <ClInclude Include="Headers\BoidEngine.h" />
     <ClInclude Include="Headers\CommandHandler.h" />
     <ClInclude Include="Headers\Emitter.h" />
     <ClInclude Include="Headers\EmitterEngine.h" />
@@ -55,8 +53,6 @@
     <ClInclude Include="TestClass.h" />
   </ItemGroup>
   <ItemGroup>
-    <ClCompile Include="Source\Anim_Track.cpp" />
-    <ClCompile Include="Source\BoidEngine.cpp" />
     <ClCompile Include="Source\CommandHandler.cpp" />
     <ClCompile Include="Source\Emitter.cpp" />
     <ClCompile Include="Source\EmitterEngine.cpp" />

--- a/Renderer.vcxproj.filters
+++ b/Renderer.vcxproj.filters
@@ -54,13 +54,7 @@
     <ClInclude Include="Headers\TextureManager.h">
       <Filter>Header Files</Filter>
     </ClInclude>
-    <ClInclude Include="Headers\Anim_Track.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
     <ClInclude Include="Headers\MeshManager.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
-    <ClInclude Include="Headers\BoidEngine.h">
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="Headers\EntityComponentHeaders\EntityComponent.h">
@@ -155,13 +149,7 @@
     <ClCompile Include="Source\TextureManager.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
-    <ClCompile Include="Source\Anim_Track.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
     <ClCompile Include="Source\MeshManager.cpp">
-      <Filter>Source Files</Filter>
-    </ClCompile>
-    <ClCompile Include="Source\BoidEngine.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="Source\EntityManager.cpp">

--- a/Source/Entities/InteractableEntity.cpp
+++ b/Source/Entities/InteractableEntity.cpp
@@ -22,18 +22,12 @@ InteractableEntity::~InteractableEntity()
 void InteractableEntity::loadAsBillboard(const vec3* vNormal, int iHeight, int iWidth, const Material* pMaterial)
 {
 	// Load Render Component and get Texture Dimensions
-	int iTextureHeight(0), iTextureWidth(0);
-	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, true, ShaderManager::eShaderType::BILLBOARD_SHDR, GL_POINTS);
-	assert(nullptr != m_pRenderComponent);
-	m_pRenderComponent->loadMaterial(pMaterial);
-	m_pRenderComponent->getDiffuseTextureDimensions(&iTextureHeight, &iTextureWidth);
 	vec2 vUVStart = vec2(0.0f);
-	vec2 vUVEnd = vec2(	static_cast<float>(iWidth) / static_cast<float>(iTextureWidth),
-						static_cast<float>(iHeight) / static_cast<float>(iTextureHeight));
+	vec2 vUVEnd = vec2(	1.0f );
 
 	// Generate the Mesh
-	m_pBillboardMesh = MESH_MANAGER->generateBillboardMesh(m_vPosition, *vNormal, vUVStart, vUVEnd, iHeight, iWidth );
+	m_pBillboardMesh = MESH_MANAGER->generateBillboardMesh(m_vPosition, *vNormal, vUVStart, vUVEnd, iHeight, iWidth, pMaterial);
 
-	// Initialize Render Component with Mesh.
-	m_pRenderComponent->initializeComponent(m_pBillboardMesh);
+	// Generate the Render Component
+	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, m_pBillboardMesh, true, ShaderManager::eShaderType::BILLBOARD_SHDR, GL_POINTS);
 }

--- a/Source/Entities/PlayerEntity.cpp
+++ b/Source/Entities/PlayerEntity.cpp
@@ -20,10 +20,6 @@ void PlayerEntity::initializePlayer(const string& sFileName,
 									float fScale)
 {
 	// Load Mesh and Rendering Component
-	m_pMesh = MESH_MANAGER->loadMeshFromFile(sFileName, fScale, m_vPosition);
-	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, false, SHADER_MANAGER->getShaderType(sShaderType), GL_TRIANGLES);
-
-	// Ensure that the Entity Manager returned a Render Component and Initialize it.
-	assert(nullptr != m_pRenderComponent);
-	m_pRenderComponent->initializeComponent(m_pMesh, pMaterial);
+	m_pMesh = MESH_MANAGER->loadMeshFromFile(sFileName, pMaterial, fScale, m_vPosition);
+	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, m_pMesh, false, SHADER_MANAGER->getShaderType(sShaderType), GL_TRIANGLES);
 }

--- a/Source/Entities/PointLight.cpp
+++ b/Source/Entities/PointLight.cpp
@@ -30,21 +30,15 @@ void PointLight::initialize(float fPower, const vec3* vColor, bool bStatic, cons
 	// Load Mesh
 	if ("" == sMeshName)
 	{
-		m_pMesh = MESH_MANAGER->generateCubeMesh(bStatic, LIGHT_HEIGHT, LIGHT_WIDTH, LIGHT_DEPTH, m_vPosition);
+		m_pMesh = MESH_MANAGER->generateCubeMesh(bStatic, LIGHT_HEIGHT, LIGHT_WIDTH, LIGHT_DEPTH, pMaterial, m_vPosition);
 	}
 	else
 	{
-		m_pMesh = MESH_MANAGER->loadMeshFromFile(sMeshName, m_fMeshScale, m_vPosition, bStatic);
+		m_pMesh = MESH_MANAGER->loadMeshFromFile(sMeshName, pMaterial, m_fMeshScale, m_vPosition, bStatic);
 	}
 
 	// Create a Render Component
-	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, bStatic, ShaderManager::eShaderType::LIGHT_SHDR, GL_TRIANGLES);
-
-	// Initialize Render Component
-	assert(m_pRenderComponent != nullptr);
-	m_pRenderComponent->initializeComponent(m_pMesh, pMaterial);
-	vec4 pPoweredColor = vec4( m_pColor, 1.0 ) * fPower;
-	m_pRenderComponent->generateDiffuseTexture(&pPoweredColor); // Generates a Texture for the light based on the light color.
+	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, m_pMesh, bStatic, ShaderManager::eShaderType::LIGHT_SHDR, GL_TRIANGLES);
 
 	// Create and Initialize the Lighting Component.
 	m_pLightingComponent = ENTITY_MANAGER->generateLightingComponent(m_iID);

--- a/Source/Entities/SpotLight.cpp
+++ b/Source/Entities/SpotLight.cpp
@@ -29,18 +29,12 @@ void SpotLight::initialize(float fPhi, float fSoftPhi, bool bStatic, const vec3*
 
 	// Load Mesh
 	if ("" == sMeshLocation)
-		m_pMesh = MESH_MANAGER->generateSphereMesh(bStatic, 0.25f, m_vPosition);
+		m_pMesh = MESH_MANAGER->generateSphereMesh(bStatic, 0.25f, sMaterial, m_vPosition);
 	else
-		m_pMesh = MESH_MANAGER->loadMeshFromFile(sMeshLocation, m_fMeshScale, m_vPosition, bStatic);
+		m_pMesh = MESH_MANAGER->loadMeshFromFile(sMeshLocation, sMaterial, m_fMeshScale, m_vPosition, bStatic);
 
 	// Create a Render Component
-	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, bStatic, ShaderManager::eShaderType::LIGHT_SHDR, GL_TRIANGLE_STRIP);
-
-	// Initialize Render Component
-	assert(m_pRenderComponent != nullptr);
-	m_pRenderComponent->initializeComponent(m_pMesh, sMaterial);
-	vec4 pPoweredColor = vec4( m_pColor, 1.0);
-	m_pRenderComponent->generateDiffuseTexture(&pPoweredColor); // Generates a Texture for the light based on the light color.
+	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, m_pMesh, bStatic, ShaderManager::eShaderType::LIGHT_SHDR, GL_TRIANGLE_STRIP);
 
 	// Create and Initialize the Lighting Component.
 	m_pLightingComponent = ENTITY_MANAGER->generateLightingComponent(m_iID);

--- a/Source/Entities/StaticEntity.cpp
+++ b/Source/Entities/StaticEntity.cpp
@@ -21,33 +21,23 @@ StaticEntity::~StaticEntity()
 // Load a Plane with a given Normal, Height and Width
 void StaticEntity::loadAsPlane(const vec3* vNormal, int iHeight, int iWidth, const Material* pMaterial, const string& sShaderType)
 {
-	m_pMesh = MESH_MANAGER->generatePlaneMesh( true, iHeight, iWidth, m_vPosition, *vNormal);
-	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, true, SHADER_MANAGER->getShaderType(sShaderType), GL_TRIANGLE_STRIP);
-
-	assert(nullptr != m_pRenderComponent);
-	m_pRenderComponent->initializeComponent( m_pMesh, pMaterial);
+	m_pMesh = MESH_MANAGER->generatePlaneMesh( true, iHeight, iWidth, pMaterial, m_vPosition, *vNormal);
+	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, m_pMesh, true, SHADER_MANAGER->getShaderType(sShaderType), GL_TRIANGLE_STRIP);
 }
 
 // Load a Sphere with a given Radius
 void StaticEntity::loadAsSphere(float fRadius, const Material* pMaterial, const string& sShaderType)
 {
-	m_pMesh = MESH_MANAGER->generateSphereMesh(true, fRadius, m_vPosition);
-	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, true, SHADER_MANAGER->getShaderType(sShaderType), GL_TRIANGLE_STRIP);
-
-	assert(nullptr != m_pRenderComponent);
-	m_pRenderComponent->initializeComponent(m_pMesh, pMaterial);
+	m_pMesh = MESH_MANAGER->generateSphereMesh(true, fRadius, pMaterial, m_vPosition);
+	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, m_pMesh, true, SHADER_MANAGER->getShaderType(sShaderType), GL_TRIANGLE_STRIP);
 }
 
 // Load a Static Mesh from a given file
 void StaticEntity::loadFromFile(const string& sFileName, const Material* pMaterial, const string& sShaderType, float fScale)
 {
 	// Grab the Mesh Object
-	m_pMesh = MESH_MANAGER->loadMeshFromFile(sFileName, fScale, m_vPosition, true);
+	m_pMesh = MESH_MANAGER->loadMeshFromFile(sFileName, pMaterial, fScale, m_vPosition, true);
 
 	// Set up Render component
-	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, true, SHADER_MANAGER->getShaderType(sShaderType), GL_TRIANGLES);
-
-	// Given that the component was generated successfully, initialize it.
-	assert(nullptr != m_pRenderComponent);
-	m_pRenderComponent->initializeComponent(m_pMesh, pMaterial);
+	m_pRenderComponent = ENTITY_MANAGER->generateRenderComponent(m_iID, m_pMesh, true, SHADER_MANAGER->getShaderType(sShaderType), GL_TRIANGLES);
 }

--- a/Source/EntityComponents/RenderComponent.cpp
+++ b/Source/EntityComponents/RenderComponent.cpp
@@ -1,9 +1,6 @@
 #include "EntityComponentHeaders/RenderComponent.h"
 #include "EntityManager.h"
 
-const string DEFAULT_DIFFUSE_MAP = "textures/defaultTexture.jpg";
-const vec4 DEFAULT_SPEC_COLOR = vec4(vec3(0.f), 1.0f);
-
 // Default Constructor:
 //		Requires an EntityID for the Entity that the component is a part of
 //			and a ComponentID issued by the EntityManager.
@@ -16,9 +13,6 @@ RenderComponent::RenderComponent(int iEntityID, int iComponentID, bool bStaticDr
 	m_eShaderType = eType;
 	m_eMode = eMode;
 	m_pShdrMngr = SHADER_MANAGER;
-	m_sRenderMaterial.fShininess = 0.0f;
-	m_sRenderMaterial.m_pDiffuseMap = nullptr;
-	m_sRenderMaterial.m_pSpecularMap = nullptr;
 }
 
 // Destructor
@@ -35,9 +29,7 @@ void RenderComponent::render()
 	glUseProgram(m_pShdrMngr->getProgram(m_eShaderType));
 
 	// Bind Texture(s) HERE
- 	m_sRenderMaterial.m_pDiffuseMap->bindTexture(m_eShaderType, "sMaterial.vDiffuse");
-	m_sRenderMaterial.m_pSpecularMap->bindTexture(m_eShaderType, "sMaterial.vSpecular");
-	m_pShdrMngr->setUniformFloat(m_eShaderType, "sMaterial.fShininess", m_sRenderMaterial.fShininess);
+	m_pMesh->bindTextures(m_eShaderType);
 
 	// Call related glDraw function.
 	if (m_bUsingInstanced)
@@ -48,8 +40,7 @@ void RenderComponent::render()
 		glDrawArrays(m_eMode, 0, m_iCount);
 
 	// Unbind Texture(s) HERE
-	m_sRenderMaterial.m_pDiffuseMap->unbindTexture();
-	m_sRenderMaterial.m_pSpecularMap->unbindTexture();
+	m_pMesh->unbindTextures();
 }
 
 // Overloaded Update Function
@@ -58,17 +49,13 @@ void RenderComponent::update(double dTimeDelta)
 
 }
 
-void RenderComponent::initializeComponent(const Mesh* pMesh, 
-										  const Material* pMaterial)
+void RenderComponent::initializeComponent(const Mesh* pMesh)
 {
 	// Ensure the Mesh passed in is valid.
 	assert(nullptr != pMesh);
 
 	// Get number of Vertices.
 	m_iCount = pMesh->getCount();
-
-	// Load the Material
-	loadMaterial(pMaterial);
 
 	// Check Rendering Flags in Mesh.
 	m_bUsingIndices = pMesh->usingIndices();
@@ -77,44 +64,4 @@ void RenderComponent::initializeComponent(const Mesh* pMesh,
 	// Store Mesh for Reference.
 	m_pMesh = pMesh;
 	m_iVertexArray = pMesh->getVertexArray();	// Store Vertex Array Locally.
-}
-
-// Generates a simple 1x1 diffuse texture based on the given color.
-void RenderComponent::generateDiffuseTexture(const vec4* vColor)
-{
-	m_sRenderMaterial.m_pDiffuseMap = TEXTURE_MANAGER->genTexture(vColor);
-}
-
-// Function to load a Material. Checks passed in material and loads a default if necessary.
-// Overwrites any currently loaded Material with the new material if applicable. 
-//	Texture Manager manages the textures using unique pointers, therefore, no memory is lost by simply replacing existing textures.
-void RenderComponent::loadMaterial(const Material* pMaterial)
-{
-	if (nullptr != pMaterial)
-	{
-		// Load Diffuse Texture if applicable
-		if ("" != pMaterial->sDiffuseMap)
-			m_sRenderMaterial.m_pDiffuseMap = TEXTURE_MANAGER->loadTexture(pMaterial->sDiffuseMap);
-
-		// Load Texture if applicable
-		if ("" != pMaterial->sOptionalSpecMap)
-			m_sRenderMaterial.m_pSpecularMap = TEXTURE_MANAGER->loadTexture(pMaterial->sOptionalSpecMap);
-		else	// "" as Spec Map Location? just generate a texture from whatever the Spec Shade is.
-			m_sRenderMaterial.m_pSpecularMap = TEXTURE_MANAGER->genTexture(&pMaterial->vOptionalSpecShade);
-
-		// Store Shininess
-		m_sRenderMaterial.fShininess = pMaterial->fShininess;
-	}
-
-	// Set some defaults if no Maps were specified.
-	if (nullptr == m_sRenderMaterial.m_pDiffuseMap)
-		m_sRenderMaterial.m_pDiffuseMap = TEXTURE_MANAGER->loadTexture(DEFAULT_DIFFUSE_MAP);
-	if (nullptr == m_sRenderMaterial.m_pSpecularMap)
-		m_sRenderMaterial.m_pSpecularMap = TEXTURE_MANAGER->genTexture(&DEFAULT_SPEC_COLOR);
-}
-
-void RenderComponent::getDiffuseTextureDimensions(int* iHeight, int* iWidth)
-{
-	if (nullptr != m_sRenderMaterial.m_pDiffuseMap)
-		m_sRenderMaterial.m_pDiffuseMap->getTextureDimensions(iHeight, iWidth);
 }

--- a/Source/Mesh.cpp
+++ b/Source/Mesh.cpp
@@ -1,5 +1,12 @@
 #include "Mesh.h"
 #include <sstream>
+#include "TextureManager.h"
+
+/****************************\
+ * Constants: For Materials *
+\****************************/
+const string DEFAULT_DIFFUSE_MAP = "textures/defaultTexture.jpg";
+const vec4 DEFAULT_SPEC_COLOR = vec4(vec3(0.f), 1.0f);
 
 /************************************\
  * Defines: For Sphere Construction *
@@ -21,12 +28,14 @@
 #define DIMENSION_OFFSET	((sizeof(vec3) << 1) + (sizeof(vec2) << 1))
 
 // Basic Constructor
-Mesh::Mesh( const string &sManagerKey, bool bStaticMesh, manager_cookie )
+Mesh::Mesh( const string &sManagerKey, bool bStaticMesh, const Material* pMaterial, manager_cookie )
 {
 	m_sManagerKey = sManagerKey;
 	m_bStaticMesh = bStaticMesh;
 	m_pShdrMngr = SHADER_MANAGER;
 	glGenVertexArrays(1, &m_iVertexArray);
+
+	loadMaterial(pMaterial);
 }
 
 // Delete any buffers that we initialized
@@ -55,6 +64,8 @@ bool Mesh::genMesh( const string& sFileName, vec3 vPosition, float fScale )
 	{
 		// Apply Scale before Translation
 		mat4 m4Transformation = scale(vec3(fScale)) * mat4(1.0f);
+
+		// Translation
 		if (vec3(0.f) != vPosition)
 			m4Transformation = translate(vPosition) * m4Transformation;
 
@@ -98,21 +109,9 @@ void Mesh::genPlane(int iHeight, int iWidth, vec3 vPosition, vec3 vNormal)
 	// Generate Indices
 	m_pIndices = { 0, 1, 2, 1, 2, 3 };
 
-	// Initial Translation Matrix
-	mat4 m4TranslationMatrix = mat4(1.0f);
-
-	float d = dot(vNormal, vec3(0.f, 1.f, 0.f) );
-	if (d < 1.f) // If d >= 1.f, Vectors are the same.
-	{
-		// create Rotation quaternion to rotate plane.
-		vec3 vCross = cross(vNormal, vec3(0.f, 1.f, 0.f));
-		quat q = angleAxis(acos(d), vCross);
-		normalize(q);
+	// Translation Matrix
+	mat4 m4TranslationMatrix = getRotationMat4ToNormal(&vNormal);
 	
-		// Rotate Plane
-		m4TranslationMatrix = toMat4(q) * m4TranslationMatrix;
-	}
-
 	// If translation is necessary, translate plane.
 	if (vec3(0.f) != vPosition)
 		m4TranslationMatrix = translate(vPosition) * m4TranslationMatrix;
@@ -331,7 +330,6 @@ void Mesh::genCube(int iHeight, int iWidth, int iDepth, vec3 vPosition)
 // This will store the position as a vertex with a given normal as the direction to draw the billboard in.
 //	the height and width will be set up and stored in the VBO as well.
 //	The billboard functionality of a Mesh will set up the VBOs in a very different manner:
-//		- Still instanced, a translation matrix will be specified for each vertex
 //		- For each data entry:
 //			* Vertex (vec3)
 //			* Normal (vec3)
@@ -659,16 +657,16 @@ void Mesh::loadInstanceData(const void* pData, unsigned int iSize)
 	if (nullptr != pData)
 	{
 		glBindBuffer(GL_ARRAY_BUFFER, m_iInstancedBuffer);
-		glBufferData(GL_ARRAY_BUFFER, iSize * sizeof(mat4), pData, GL_STREAM_DRAW);
+		glBufferData(GL_ARRAY_BUFFER, iSize * sizeof(mat4), pData, GL_DYNAMIC_DRAW);
 	}
 }
 
 // Taking in a new Position a Rotation Quaternion and a Scale, add a new transformation matrix to the internal list and updates the VBO.
-void Mesh::addInstance(const vec3* vPosition, quat qRotation, float fScale)
+void Mesh::addInstance(const vec3* vPosition, const vec3* vNormal, float fScale)
 {
 	// Order as Scale -> Rotation -> Translation
 	mat4 m4NewTransform = scale(vec3(fScale));
-	m4NewTransform = toMat4(qRotation) * m4NewTransform;
+	m4NewTransform = getRotationMat4ToNormal(vNormal) * m4NewTransform;
 	m4NewTransform = translate(*vPosition) * m4NewTransform;
 
 	// Utilize Overloaded Function for functionality.
@@ -689,3 +687,81 @@ void Mesh::addInstance(const mat4* m4Transform)
 	// Load VBO with new Data.
 	loadInstanceData(m_m4ListOfInstances.data(), m_m4ListOfInstances.size());
 }
+
+// Returns a Rotation Matrix to rotate an object from a World Coordinate System to a Local
+//	coordinate system with a given y-axis normal.
+mat4 Mesh::getRotationMat4ToNormal(const vec3* vNormal)
+{
+	// Initial Translation Matrix
+	mat4 m4ReturnMatrix = mat4(1.0f);
+	vec3 vYAxis(0.0f, 1.0f, 0.0f);
+
+	float d = dot(*vNormal, vYAxis);
+	if (d < 1.f) // If d >= 1.f, Vectors are the same.
+	{
+		// create Rotation quaternion.
+		vec3 vCross = cross(*vNormal, vYAxis);
+		quat q = angleAxis(acos(d), vCross);
+		normalize(q);
+
+		// Create Rotation Matrix from Quaternion
+		m4ReturnMatrix = toMat4(q) * m4ReturnMatrix;
+	}
+
+	// Return Rotation Matrix
+	return m4ReturnMatrix;
+}
+
+/************************************************************************************\
+ * Texture Functionality															*
+\************************************************************************************/
+
+// Function to Bind the Mesh Material to the Shader for Rendering
+//	To be called before the render function
+void Mesh::bindTextures(ShaderManager::eShaderType eShaderType) const
+{
+	// Bind the Diffuse and Specular Maps
+	m_sRenderMaterial.m_pDiffuseMap->bindTexture(eShaderType, "sMaterial.vDiffuse");
+	m_sRenderMaterial.m_pSpecularMap->bindTexture(eShaderType, "sMaterial.vSpecular");
+
+	// Set the Material's Shininess in the Material Uniform in the shader.
+	m_pShdrMngr->setUniformFloat(eShaderType, "sMaterial.fShininess", m_sRenderMaterial.fShininess);
+}
+
+// Funtion to unbind textures. To be called after a render call on this mesh.
+void Mesh::unbindTextures() const
+{
+	m_sRenderMaterial.m_pDiffuseMap->unbindTexture();
+	m_sRenderMaterial.m_pSpecularMap->unbindTexture();
+}
+
+// Function to Load a given material to the internal Render Material struct.
+//	This defines a specular and diffuse map as well as a shininess factor
+//	for this mesh that is used for rendering.
+void Mesh::loadMaterial(const Material* pMaterial)
+{
+	if (nullptr != pMaterial)
+	{
+		// Load Diffuse Texture if applicable
+		if ("" != pMaterial->sDiffuseMap)
+			m_sRenderMaterial.m_pDiffuseMap = TEXTURE_MANAGER->loadTexture(pMaterial->sDiffuseMap);
+		else if (vec4(0.0f) != pMaterial->vOptionalDiffuseColor)	// No diffuse Texture applicable? then check if there's a specified diffuse color for the material.
+			m_sRenderMaterial.m_pDiffuseMap = TEXTURE_MANAGER->genTexture(&pMaterial->vOptionalDiffuseColor);
+
+		// Load Texture if applicable
+		if ("" != pMaterial->sOptionalSpecMap)
+			m_sRenderMaterial.m_pSpecularMap = TEXTURE_MANAGER->loadTexture(pMaterial->sOptionalSpecMap);
+		else	// "" as Spec Map Location? just generate a texture from whatever the Spec Shade is.
+			m_sRenderMaterial.m_pSpecularMap = TEXTURE_MANAGER->genTexture(&pMaterial->vOptionalSpecShade);
+
+		// Store Shininess
+		m_sRenderMaterial.fShininess = pMaterial->fShininess;
+	}
+
+	// Set some defaults if no Maps were specified.
+	if (nullptr == m_sRenderMaterial.m_pDiffuseMap)
+		m_sRenderMaterial.m_pDiffuseMap = TEXTURE_MANAGER->loadTexture(DEFAULT_DIFFUSE_MAP);
+	if (nullptr == m_sRenderMaterial.m_pSpecularMap)
+		m_sRenderMaterial.m_pSpecularMap = TEXTURE_MANAGER->genTexture(&DEFAULT_SPEC_COLOR);
+}
+

--- a/scene2.scene
+++ b/scene2.scene
@@ -40,8 +40,9 @@
 #		cube	{ x y z  height  width  depth }  ** NOT YET IMPLEMENTED **
 #			- "x y z"				= the position of the cube
 #			- "height width depth"	= Specifies the dimensions of the cube
-#		static_mesh { x y z }
-#			- "x y z"				= the position of the mesh
+#		static_mesh { x y z... }
+#			- "x y z..."			= the position of the mesh
+#									= multiple positions can be specified for instanced rendering
 #
 # ============================================================
 # Attributes
@@ -207,6 +208,12 @@ player {
 
 static_mesh {
 	0 0 10
+	0 10 0
+	10 0 0
+	10 10 0
+	10 0 10
+	0 10 10
+	10 10 10
 	+mesh {
 		models/bunny.obj
 		5.0


### PR DESCRIPTION
I overhauled the Mesh/RenderComponent relationship. This allows for Materials to be specified per mesh object. Therefore, any mesh that may be the same mesh but has different materials will be created as a separate mesh. The benefit of this is that any static mesh that uses the same material can be associated with a single mesh, but multiple transformation matrices. Therefore, there is less draw calls required for many static meshes of the same mesh with the same material as well as less space required for storing this information in the program.

The Entity Manager now stores rendering components in a hashmap with the Mesh pointer as a Hashkey. This trick allows many static meshes to maintain their individuality w.r.t. physics and identity/message, but all use the same mesh and rendercomponent as each other for faster rendering speeds.

This change also bred a small change to the scene loader. Particularly for Static Meshes, now you can specify an array of positions along with the material, mesh and shader for the objects and it will generate them in an instanced manner as explained above.